### PR TITLE
:memo: Fix link and punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Atomdoc is a code documentation format based on markdown. The atom team writes a
 
 ## Usage
 
-It's on [npm](https://www.npmjs.org/package/atomdoc)
+It's on [npm](https://www.npmjs.org/package/atomdoc).
 
 ```
 npm install atomdoc
@@ -175,7 +175,7 @@ doc = AtomDoc.parse(docString)
 
 ## Notes
 
-The parser uses [marked]'s lexer.
+The parser uses [marked][marked]'s lexer.
 
 
-[marked]:https://github.com/chjj/marked
+[marked]: https://github.com/chjj/marked


### PR DESCRIPTION
cc @benogle 

Just a couple quick tweaks.

I would have submitted this directly to the repo, but it looks like `atom/atomdoc` isn't one of the "non-github-maintainers" team's repos.
