### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docString = """
   ```coffee
   myMethod 20, ({someOption, anotherOption}) ->
     console.log someOption, anotherOption
-  `` `
+  ```
 
   Returns null in some case
   Returns an {Object} with the keys:


### PR DESCRIPTION
Remove unintentional space in code example in Markdown in documentation example.