### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,40 +42,40 @@ Using all the features.
 AtomDoc = require 'atomdoc'
 
 docString = """
-  Public: My awesome method that does stuff.
-
-  It does things and stuff and even more things, this is the description. The
-  next section is the arguments. They can be nested. Useful for explaining the
-  arguments passed to any callbacks.
-
-  * `count` {Number} representing count
-  * `callback` {Function} that will be called when finished
-    * `options` Options {Object} passed to your callback with the options:
-      * `someOption` A {Bool}
-      * `anotherOption` Another {Bool}
-
-  ## Events
-
-  ### contents-modified
-
-  Public: Fired when this thing happens.
-
-  * `options` {Object} An options hash
-    * `someOption` {Object} An options hash
-
-  ## Examples
-
-  This is an example. It can have a description.
-
-  ```coffee
-  myMethod 20, ({someOption, anotherOption}) ->
-    console.log someOption, anotherOption
-  ```
-
-  Returns null in some cases
-  Returns an {Object} with these keys:
-    * `someBool` a {Boolean}
-    * `someNumber` a {Number}
+    Public: My awesome method that does stuff.
+  
+    It does things and stuff and even more things, this is the description. The
+    next section is the arguments. They can be nested. Useful for explaining the
+    arguments passed to any callbacks.
+  
+    * `count` {Number} representing count
+    * `callback` {Function} that will be called when finished
+      * `options` Options {Object} passed to your callback with the options:
+        * `someOption` A {Bool}
+        * `anotherOption` Another {Bool}
+  
+    ## Events
+  
+    ### contents-modified
+  
+    Public: Fired when this thing happens.
+  
+    * `options` {Object} An options hash
+      * `someOption` {Object} An options hash
+  
+    ## Examples
+  
+    This is an example. It can have a description.
+  
+    ```coffee
+    myMethod 20, ({someOption, anotherOption}) ->
+      console.log someOption, anotherOption
+    ```
+  
+    Returns null in some cases
+    Returns an {Object} with these keys:
+      * `someBool` a {Boolean}
+      * `someNumber` a {Number}
 """
 doc = AtomDoc.parse(docString)
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docString = """
   ```coffee
   myMethod 20, ({someOption, anotherOption}) ->
     console.log someOption, anotherOption
-  `` `
+  ```
 
   Returns null in some cases
   Returns an {Object} with these keys:


### PR DESCRIPTION
Fixes https://github.com/atom/markdown-preview/issues/167. (cc @lee-dohm)

This was a problem within a problem. The reason why the link was broken is that a code block didn't have a valid closing fence 9d65982. Fixing that however caused the whole containing code block to break because of nested fenced code block. I fixed this by increasing the indentation level within the code block 8c6ef66.

Also cc @mdiep in case he knows of a better way to fix this or has any tips on where to report the issue (doesn't seem to be a problem in redcarpet).