### PR TITLE
Fix parsing return statements containing 'undefined'

### DIFF
--- a/spec/parser-spec.coffee
+++ b/spec/parser-spec.coffee
@@ -861,3 +861,17 @@ describe "parser", ->
           ```
         """
       }]
+    it "parses return when it contains the keyword undefined", ->
+      str = """
+         Public: Get the active {Package} with the given name.
+
+         Returns undefined.
+      """
+      doc = parse(str)
+
+      expect(doc.returnValues).toEqualJson [{
+        type: null,
+        description: """
+          Returns undefined.
+        """
+      }]

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -166,12 +166,12 @@ parseReturnValues = (tokens, consumeTokensAfterReturn=false) ->
   firstToken = _.first(tokens)
   return unless firstToken and firstToken.type in ['paragraph', 'text'] and isReturnValue(firstToken.text)
 
-  returnsMatches = new RegExp(ReturnsRegex).exec(firstToken.text) # there might be a `Public: ` in front of the return.
   if consumeTokensAfterReturn
-    normalizedString = generateDescription(tokens, -> true).replace(returnsMatches[1], '')
+    # there might be a `Public: ` in front of the return.
+    normalizedString = generateDescription(tokens, -> true).replace(new RegExp(VisibilityRegex), '')
   else
     token = tokens.shift()
-    normalizedString = token.text.replace(returnsMatches[1], '').replace(/\s{2,}/g, ' ')
+    normalizedString = token.text.replace(new RegExp(VisibilityRegex), '').replace(/\s{2,}/g, ' ')
 
 
   returnValues = null


### PR DESCRIPTION
The parser removes occurences of the string 'undefined' in Return value descriptions.
Real life example taken from [atom](https://github.com/atom/atom/blob/v1.5.4/src/package-manager.coffee#L224):

```
Public: Get the active {Package} with the given name.

* `name` - The {String} package name.

Returns a {Package} or undefined.
```

[Result:](https://atom.io/docs/api/v1.5.4/PackageManager#instance-getActivePackage)

```
Return values:
Returns a Package or .
```

This happens when the optionally matched visibility specifier is not present, which leads to `returnsMatches[1]` being undefined and thus, "... undefined ...".replace(undefined, '') evaluates to `'... ...'`.

I have added a test case and fixed the problem.
