### PR TITLE
update description in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atomdoc",
   "version": "1.0.4",
-  "description": "A atomdoc parser",
+  "description": "An atomdoc parser",
   "main": "./lib/atomdoc.js",
   "scripts": {
     "test": "grunt test",


### PR DESCRIPTION
GrammarGirl says:

> use `a` before words that start with a consonant sound and `an` before words that start with a vowel sound