### PR TITLE
Ensure a match exists before replacing text with it

### DIFF
--- a/spec/parser-spec.coffee
+++ b/spec/parser-spec.coffee
@@ -861,3 +861,17 @@ describe "parser", ->
           ```
         """
       }]
+    it "parses return when it contains the keyword undefined", ->
+      str = """
+         Public: Get the active {Package} with the given name.
+
+         Returns undefined.
+      """
+      doc = parse(str)
+
+      expect(doc.returnValues).toEqualJson [{
+        type: null,
+        description: """
+          Returns undefined.
+        """
+      }]

--- a/spec/parser-spec.coffee
+++ b/spec/parser-spec.coffee
@@ -875,3 +875,17 @@ describe "parser", ->
           Returns undefined.
         """
       }]
+    it "parses return when it contains the keyword `undefined`", ->
+      str = """
+         Public: Get the active {Package} with the given name.
+
+         Returns `undefined`.
+      """
+      doc = parse(str)
+
+      expect(doc.returnValues).toEqualJson [{
+        type: null,
+        description: """
+          Returns `undefined`.
+        """
+      }]

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -64,7 +64,7 @@ parseSummaryAndDescription = (tokens, tokenCallback=stopOnSectionBoundaries) ->
     if visibilityMatch = new RegExp(VisibilityRegex).exec(rawSummary)
       visibility = visibilityMatch[1]
       rawVisibility = visibilityMatch[0]
-      rawSummary = rawSummary.replace(rawVisibility, '')
+      rawSummary = rawSummary.replace(rawVisibility, '') if rawVisibility?
 
   if isReturnValue(rawSummary)
     returnValues = parseReturnValues(tokens, false)
@@ -168,10 +168,15 @@ parseReturnValues = (tokens, consumeTokensAfterReturn=false) ->
 
   returnsMatches = new RegExp(ReturnsRegex).exec(firstToken.text) # there might be a `Public: ` in front of the return.
   if consumeTokensAfterReturn
-    normalizedString = generateDescription(tokens, -> true).replace(returnsMatches[1], '')
+    normalizedString = generateDescription(tokens, -> true)
+    if returnsMatches[1]?
+      normalizedString = normalizedString.replace(returnsMatches[1], '')
   else
     token = tokens.shift()
-    normalizedString = token.text.replace(returnsMatches[1], '').replace(/\s{2,}/g, ' ')
+    normalizedString = token.text
+    if returnsMatches[1]?
+      normalizedString = normalizedString.replace(returnsMatches[1], '')
+    normalizedString = normalizedString.replace(/\s{2,}/g, ' ')
 
 
   returnValues = null
@@ -264,7 +269,7 @@ parseListItem = (argumentString) ->
 
   if nameMatches = new RegExp(ArgumentListItemRegex).exec(argumentString)
     name = nameMatches[1]
-    description = description.replace(nameMatches[0], '')
+    description = description.replace(nameMatches[0], '') if nameMatches[0]?
     type = getLinkMatch(description)
     isOptional = !!nameMatches[3]
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -269,7 +269,7 @@ parseListItem = (argumentString) ->
 
   if nameMatches = new RegExp(ArgumentListItemRegex).exec(argumentString)
     name = nameMatches[1]
-    description = description.replace(nameMatches[0], '') if nameMatches[0]?
+    description = description.replace(nameMatches[0], '')
     type = getLinkMatch(description)
     isOptional = !!nameMatches[3]
 


### PR DESCRIPTION
Previously if a match was `undefined` (the value!), it was getting translated to the string `undefined`, and this was causing that word to be replaced anywhere it was found in the string.

Fixes #15.
Closes #7. (I only saw this PR _after_ writing this, but I think mine is a more complete solution.)