### PR TITLE
Update most dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
     on_failure: change
 
 node_js:
-  - 0.10
+  - 6
 
 git:
   depth: 10

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -23,10 +23,6 @@ module.exports = (grunt) ->
     shell:
       test:
         command: 'jasmine-focused --captureExceptions --coffee spec/'
-        options:
-          stdout: true
-          stderr: true
-          failOnError: true
 
   grunt.loadNpmTasks('grunt-contrib-coffee')
   grunt.loadNpmTasks('grunt-shell')

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-coffeelint": "0.0.6",
+    "grunt-coffeelint": "0.0.16",
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-shell": "~0.2.2",
     "jasmine-focused": "1.x",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-coffeelint": "0.0.16",
-    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-contrib-coffee": "^1.0.0",
     "grunt-shell": "^2.1.0",
     "jasmine-focused": "1.x",
     "jasmine-json": "~0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt": "^1.0.1",
     "grunt-coffeelint": "0.0.16",
     "grunt-contrib-coffee": "~0.7.0",
-    "grunt-shell": "~0.2.2",
+    "grunt-shell": "^2.1.0",
     "jasmine-focused": "1.x",
     "jasmine-json": "~0.0",
     "rimraf": "^2.5.2"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "underscore": "~1.6"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-cli": "~0.1.8",
+    "grunt": "^1.0.1",
     "grunt-coffeelint": "0.0.6",
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-shell": "~0.2.2",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "underscore": "~1.6"
   },
   "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.8",
+    "grunt-coffeelint": "0.0.6",
+    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-shell": "~0.2.2",
     "jasmine-focused": "1.x",
     "jasmine-json": "~0.0",
-    "grunt-contrib-coffee": "~0.7.0",
-    "grunt-cli": "~0.1.8",
-    "grunt": "~0.4.1",
-    "grunt-shell": "~0.2.2",
-    "grunt-coffeelint": "0.0.6",
     "rimraf": "^2.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "http://atom.github.io/atomdoc",
   "dependencies": {
     "marked": "^0.3.6",
-    "underscore": "~1.6"
+    "underscore": "~1.8"
   },
   "devDependencies": {
     "grunt": "^1.0.1",

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -1,5 +1,3 @@
-_ = require 'underscore'
-
 module.exports =
   getLinkMatch: (text) ->
     if m = text.match(/\{([\w.]+)\}/)


### PR DESCRIPTION
Update all the outdated dependencies to their current versions except `grunt-contrib-coffee` as that would mean an update to CoffeeScript v2 which has no set target of JS so we would potentially need further JS transpilation here.