### PR TITLE
Handle space tokens

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -415,7 +415,11 @@ const generateDescription = function (tokens, tokenCallback) {
       description.push(generateHeading(tokens))
     } else if (token.type === 'list_start') {
       description.push(generateList(tokens))
-    } else { break }
+    } else if (token.type === 'space') {
+      tokens.shift()
+    } else {
+      break
+    }
   }
 
   return description.join('\n\n')


### PR DESCRIPTION
Newer versions of `marked` are lexing additional `{ type: 'space' }` tokens for whitespace, which is turning this into an infinite loop:

https://github.com/atom/atomdoc/blob/48bad7bf44f8d280a6771b97794081b899614b84/src/parser.js#L405-L419

By consuming the space token explicitly, we can consume them properly and avoid this.

It looks like this is the root cause of atom/atom#16777.