### PR TITLE
Introduce `parseReturns` option to avoid parsing "Returns" statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It's on [npm](https://www.npmjs.org/package/atomdoc).
 npm install atomdoc
 ```
 
-It has only one method, `parse`, which takes no options.
+It has only one method, `parse`:
 
 ```coffee
 AtomDoc = require 'atomdoc'
@@ -25,6 +25,9 @@ docString = """
   no arguments.
 """
 doc = AtomDoc.parse(docString)
+
+# Alternatively, you can avoid parsing "Returns" statements in documentation (useful for class-level documentation):
+doc = AtomDoc.parse(docString, {parseReturns: false})
 ```
 
 `doc` will be an object:

--- a/spec/parser-spec.js
+++ b/spec/parser-spec.js
@@ -1007,5 +1007,37 @@ describe('parser', function () {
                 `
       }])
     })
+
+    it('ignores return statements when `parseReturns` is false', function () {
+      const str = dedent`
+        Public: Get the active {Package} with the given name.
+
+        Returns 1.
+        Returns 2.
+
+        Returns 3.
+
+        ## Section
+
+        Returns 4.
+      `
+      const doc = parse(str, {parseReturns: false})
+
+      expect(doc.visibility).toBe('Public')
+      expect(doc.summary).toBe('Get the active {Package} with the given name.')
+      expect(doc.description).toBe(dedent`
+        Get the active {Package} with the given name.
+
+        Returns 1.
+        Returns 2.
+
+        Returns 3.
+
+        ## Section
+
+        Returns 4.
+      `)
+      expect(doc.returnValues).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/16106

This option is useful when parsing class documentation. In such circumstances, a "Returns" statement will most likely refer to the usage or declaration of some method *within* the class, rather than to an
actual return value of the class itself. If such option is not supplied, atomdoc will recognize all the text after the first `Returns` token as being a return value, which makes no sense in the context of class documentation.

I will open another pull request that uses this new option in [atom/tello](https://github.com/atom/tello) shortly.

It is best to review this pull request on a commit-by-commit basis ignoring whitespace changes, since I had to refactor code a bit in order to make this change easy and as safe as possible. 